### PR TITLE
fix: attempt to index local 'str'

### DIFF
--- a/lua/barbecue/ui/entry.lua
+++ b/lua/barbecue/ui/entry.lua
@@ -48,6 +48,7 @@ end
 ---returns its length
 ---@return number
 function Entry:len()
+  local next = next
   local length = utils.str_len(self.text[1])
   if (self.icon ~= nil and next(self.icon) ~= nil) then length = length + utils.str_len(self.icon[1]) + 1 end
 
@@ -57,6 +58,7 @@ end
 ---converts itself to a string
 ---@return string
 function Entry:to_string()
+  local next = next
   return ("%" .. self.id .. "@v:lua.require'barbecue.ui.entry'.on_click@")
     .. ((self.icon == nil or next(self.icon) == nil) and "" or "%#" .. self.icon.highlight .. "#" .. utils.exp_escape(self.icon[1]) .. (self.text == nil and "" or " "))
     .. ("%#" .. self.text.highlight .. "#" .. utils.exp_escape(self.text[1]))

--- a/lua/barbecue/ui/entry.lua
+++ b/lua/barbecue/ui/entry.lua
@@ -49,7 +49,7 @@ end
 ---@return number
 function Entry:len()
   local length = utils.str_len(self.text[1])
-  if self.icon ~= nil then length = length + utils.str_len(self.icon[1]) + 1 end
+  if (self.icon ~= nil and next(self.icon) ~= nil) then length = length + utils.str_len(self.icon[1]) + 1 end
 
   return length
 end
@@ -58,7 +58,7 @@ end
 ---@return string
 function Entry:to_string()
   return ("%" .. self.id .. "@v:lua.require'barbecue.ui.entry'.on_click@")
-    .. (self.icon == nil and "" or "%#" .. self.icon.highlight .. "#" .. utils.exp_escape(self.icon[1]) .. (self.text == nil and "" or " "))
+    .. ((self.icon == nil or next(self.icon) == nil) and "" or "%#" .. self.icon.highlight .. "#" .. utils.exp_escape(self.icon[1]) .. (self.text == nil and "" or " "))
     .. ("%#" .. self.text.highlight .. "#" .. utils.exp_escape(self.text[1]))
     .. "%X"
 end


### PR DESCRIPTION
As per #22, a lot of us are encountering the error: `attempt to index local 'str' (a nil value)`.

Exploring this further, and dumping out `self.icon` from `Entry:len()` in the `entry.lua` file, I see that icons take a few forms:

- An "indexed" form:
```lua
{
  "",
  highlight = "BarbecueContextString"
}
```
- A "nil" form
```lua
nil not a table
```
- An "empty table" form
```lua
{}
```

In `Entry:len()` we account for the first two forms and not the last, causing the error. To check if the table is empty I've proposed using [next()](https://stackoverflow.com/a/1252776).