### PR TITLE
fix: load after `nvim-web-devicons` (fixes #31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ use {
     "smiteshp/nvim-navic",
     "kyazdani42/nvim-web-devicons", -- optional
   },
-  after = "nvim-web-devicons",
+  after = "nvim-web-devicons", -- NOTICE: keep this if you're using NvChad
   config = function()
     require("barbecue").setup()
   end,

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ use {
     "smiteshp/nvim-navic",
     "kyazdani42/nvim-web-devicons", -- optional
   },
+  after = "nvim-web-devicons",
   config = function()
     require("barbecue").setup()
   end,


### PR DESCRIPTION
fixes the conflict with `nvim-web-devicons` by loading `barbecue.nvim` after it.