### PR TITLE
feat(components): ability to hide directory path

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,10 @@ several things you should be aware of.
     ---@type "auto"|string|barbecue.Theme
     theme = "auto",
 
+    ---whether to display path to file
+    ---@type boolean
+    show_dirname = true,
+
     ---whether to replace file icon with the modified symbol when buffer is modified
     ---@type boolean
     show_modified = false,

--- a/lua/barbecue/config/template.lua
+++ b/lua/barbecue/config/template.lua
@@ -40,6 +40,10 @@ local M = {
   ---@type "auto"|string|barbecue.Theme
   theme = "auto",
 
+  ---whether to display path to file
+  ---@type boolean
+  show_dirname = true,
+
   ---whether to replace file icon with the modified symbol when buffer is modified
   ---@type boolean
   show_modified = false,

--- a/lua/barbecue/ui/components.lua
+++ b/lua/barbecue/ui/components.lua
@@ -9,6 +9,8 @@ local M = {}
 ---@param bufnr number
 ---@return barbecue.Entry[]
 function M.get_dirname(bufnr)
+  if not config.user.show_dirname then return {} end
+
   local filename = vim.api.nvim_buf_get_name(bufnr)
   local dirname =
     vim.fn.fnamemodify(filename, config.user.modifiers.dirname .. ":h")


### PR DESCRIPTION
It would be nice to be able to hide the directory path. I have that context in my status line so would be nice to reduce duplicate information.

`show_dirname = true` (default)
<img width="622" alt="image" src="https://user-images.githubusercontent.com/23173408/213946512-b3b1707a-a646-4b19-b4eb-ffe0e90a2cb3.png">


`show_dirname = false`
<img width="562" alt="image" src="https://user-images.githubusercontent.com/23173408/213946573-79184338-f67e-43b7-a0f5-79fb1baf239d.png">


Looks like you're autogen-ing the vimdocs, so I didn't update that by hand. Awesome plugin!