### PR TITLE
feat: omit highlight groups in string length

### DIFF
--- a/lua/barbecue/ui.lua
+++ b/lua/barbecue/ui.lua
@@ -149,8 +149,11 @@ function M.update(winnr)
     end
 
     local custom_section = config.user.custom_section(bufnr)
-    local entries =
-      create_entries(winnr, bufnr, 2 + utils.str_len(custom_section))
+    local entries = create_entries(
+      winnr,
+      bufnr,
+      2 + utils.str_len(custom_section:gsub("%%#[^#]+#", ""))
+    )
     state.save(winnr, entries)
 
     local winbar


### PR DESCRIPTION
When calculating the length of the custom section, the substrings changing the highlight group are counted although not being displayed. This leads to erroneous truncation.

Omitting the highlight groups substrings in the string length calculation fixes this issue.
