### PR TITLE
fix color hex having newline

### DIFF
--- a/lua/barbecue/utils.lua
+++ b/lua/barbecue/utils.lua
@@ -43,9 +43,9 @@ function M.get_hl_by_name(name)
     -- HACK: extract colors using string manipulation
     -- TODO: should be removed once nvim highlight APIs are fixed
     local background =
-      vim.fn.matchstr(vim.fn.execute("hi " .. name), "guibg=\\zs\\S*")
+      vim.fn.matchstr(vim.fn.execute("hi " .. name), "guibg=\\zs\\S\\k*")
     local foreground =
-      vim.fn.matchstr(vim.fn.execute("hi " .. name), "guifg=\\zs\\S*")
+      vim.fn.matchstr(vim.fn.execute("hi " .. name), "guifg=\\zs\\S\\k*")
 
     if background == "" then background = nil end
     if foreground == "" then foreground = nil end


### PR DESCRIPTION
Fixes issue with color hex having newline at end of string when `config.user.theme == "auto"`.

```
packer.nvim: Error running config for barbecue.nvim: ...ite/pack/packer/opt/barbecue.nvim/lua/barbecue/theme.lua:123: '#ffa0a0                                                                                                                                                                 
' is not a valid color
```