### PR TITLE
fix(utils): remove trailing newlines when parsing highlights

### DIFF
--- a/lua/barbecue/utils.lua
+++ b/lua/barbecue/utils.lua
@@ -42,10 +42,16 @@ function M.get_hl_by_name(name)
   then
     -- HACK: extract colors using string manipulation
     -- TODO: should be removed once nvim highlight APIs are fixed
-    local background =
-      vim.fn.matchstr(vim.fn.execute("hi " .. name), "guibg=\\zs\\S*")
-    local foreground =
-      vim.fn.matchstr(vim.fn.execute("hi " .. name), "guifg=\\zs\\S*")
+    local background = string.gsub(
+      vim.fn.matchstr(vim.fn.execute("hi " .. name), "guibg=\\zs\\S*"),
+      "\n",
+      ""
+    )
+    local foreground = string.gsub(
+      vim.fn.matchstr(vim.fn.execute("hi " .. name), "guifg=\\zs\\S*"),
+      "\n",
+      ""
+    )
 
     if background == "" then background = nil end
     if foreground == "" then foreground = nil end


### PR DESCRIPTION
In some themes like gruvbox, using barbecue causes an error and weird coloring issues across the ui. After debugging a bit I noticed *certain* gruvbox elements had a trailing \n in the call to `vim.api.nvim_set_hl`, which stemmed from the matchstr calls in utils.get_hl_by_name.

I am also curious, what's the TODO note about broken nvim highlights all about? I never knew about that, would be nice if you could briefly explain :) 

Thanks for the awesome plugin!
-Amaan