### PR TITLE
Fix ui.update to correctly honor exclude_filetypes and include_buftypes

### DIFF
--- a/lua/barbecue/ui.lua
+++ b/lua/barbecue/ui.lua
@@ -131,6 +131,19 @@ function M.update(winnr)
     then
       return
     end
+      
+    if
+      not vim.tbl_contains(config.user.include_buftypes, vim.bo[bufnr].buftype)
+      or vim.tbl_contains(config.user.exclude_filetypes, vim.bo[bufnr].filetype)
+      or vim.api.nvim_win_get_config(winnr).relative ~= ""
+    then
+      return
+    end
+      
+    if not visible then
+      vim.wo[winnr].winbar = nil
+      return
+    end
 
     local custom_section = config.user.custom_section(bufnr)
     local entries =
@@ -139,18 +152,7 @@ function M.update(winnr)
 
     local winbar
     if #entries > 0 then winbar = build_winbar(entries, custom_section) end
-    if
-        vim.tbl_contains(config.user.include_buftypes, vim.bo[bufnr].buftype)
-        and not vim.tbl_contains(config.user.exclude_filetypes, vim.bo[bufnr].filetype)
-        and not vim.api.nvim_win_get_config(winnr).relative ~= ""
-    then
-      if not visible then
-        vim.wo[winnr].winbar = nil
-        return
-      else
-        vim.wo[winnr].winbar = winbar
-      end
-    end
+    vim.wo[winnr].winbar = winbar
   end)
 end
 

--- a/lua/barbecue/ui.lua
+++ b/lua/barbecue/ui.lua
@@ -144,7 +144,12 @@ function M.update(winnr)
         and not vim.tbl_contains(config.user.exclude_filetypes, vim.bo[bufnr].filetype)
         and not vim.api.nvim_win_get_config(winnr).relative ~= ""
     then
-      vim.wo[winnr].winbar = winbar
+      if not visible then
+        vim.wo[winnr].winbar = nil
+        return
+      else
+        vim.wo[winnr].winbar = winbar
+      end
     end
   end)
 end

--- a/lua/barbecue/ui.lua
+++ b/lua/barbecue/ui.lua
@@ -123,22 +123,6 @@ function M.update(winnr)
   winnr = winnr or vim.api.nvim_get_current_win()
   local bufnr = vim.api.nvim_win_get_buf(winnr)
 
-  if
-    not vim.tbl_contains(config.user.include_buftypes, vim.bo[bufnr].buftype)
-    or vim.tbl_contains(config.user.exclude_filetypes, vim.bo[bufnr].filetype)
-    or vim.api.nvim_win_get_config(winnr).relative ~= ""
-  then
-    vim.wo[winnr].winbar = state.get_last_winbar(winnr)
-    state.clear(winnr)
-
-    return
-  end
-
-  if not visible then
-    vim.wo[winnr].winbar = nil
-    return
-  end
-
   vim.schedule(function()
     if
       not vim.api.nvim_buf_is_valid(bufnr)
@@ -155,7 +139,13 @@ function M.update(winnr)
 
     local winbar
     if #entries > 0 then winbar = build_winbar(entries, custom_section) end
-    vim.wo[winnr].winbar = winbar
+    if
+        vim.tbl_contains(config.user.include_buftypes, vim.bo[bufnr].buftype)
+        and not vim.tbl_contains(config.user.exclude_filetypes, vim.bo[bufnr].filetype)
+        and not vim.api.nvim_win_get_config(winnr).relative ~= ""
+    then
+      vim.wo[winnr].winbar = winbar
+    end
   end)
 end
 


### PR DESCRIPTION
This fixes the implementation of ui.update to correctly honor exclude_filetypes and include_buftypes so that other winbars aren't affected by barbecue.
The original implementation here could trample on other winbars in windows/buffers that shouldn't have been affected by barbecue, causing them to either be hidden, have weird behavior, or otherwise show incorrectly, because exclude_filetypes and include_buftypes were being checked in the update call, not the scheduled function to actually update the winbar.

One example of the previous conflict is with NeoTree's source_selector, which even when "neo-tree" was added to exclude_filetypes, would be broken by barbecue.nvim (it would only appear when a window other than the tree was focused, and only if the focus had changed at least once since the tree was opened).