### PR TITLE
fix(autocmd): use WindowScrolled for nvim-0.8

### DIFF
--- a/lua/barbecue/autocmd.lua
+++ b/lua/barbecue/autocmd.lua
@@ -26,11 +26,16 @@ end
 ---Update winbar on necessary events.
 function M.create_updater()
   local events = {
-    "WinResized",
     "BufWinEnter",
     "CursorMoved",
     "InsertLeave",
   }
+
+  if vim.fn.has("nvim-0.9") == 1 then
+    table.insert(events, 1, "WinResized")
+  else
+    table.insert(events, 1, "WinScrolled")
+  end
 
   if config.user.show_modified then
     utils.tbl_merge(events, {

--- a/lua/barbecue/autocmd.lua
+++ b/lua/barbecue/autocmd.lua
@@ -31,7 +31,9 @@ function M.create_updater()
     "InsertLeave",
   }
 
-  if vim.fn.has("nvim-0.9") == 1 then
+  local v = vim.version()
+
+  if v.major >= 0 and v.minor >= 9 then
     table.insert(events, 1, "WinResized")
   else
     table.insert(events, 1, "WinScrolled")


### PR DESCRIPTION
I recently found it broken in nvim 0.8.2
WinResized is coming after nvim 0.9
So you might use nvim 0.9, I make the condition where if the user uses nvim 0.9, use the WinResized else Winscrolled.