### PR TITLE
chore: pass winnr to custom sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ you've seen in the select menu of raw `:Barbecue`.
   ---NOTE: This function shouldn't do any expensive actions as it is run on each
   ---render.
   ---
-  ---@type fun(bufnr: number): barbecue.Config.custom_section
+  ---@type fun(bufnr: number, winnr: number): barbecue.Config.custom_section
   lead_custom_section = function() return " " end,
 
   ---@alias barbecue.Config.custom_section
@@ -330,7 +330,7 @@ you've seen in the select menu of raw `:Barbecue`.
   ---NOTE: This function shouldn't do any expensive actions as it is run on each
   ---render.
   ---
-  ---@type fun(bufnr: number): barbecue.Config.custom_section
+  ---@type fun(bufnr: number, winnr: number): barbecue.Config.custom_section
   custom_section = function() return " " end,
 
   ---@alias barbecue.Config.theme

--- a/doc/barbecue.txt
+++ b/doc/barbecue.txt
@@ -311,7 +311,7 @@ Click to see default config
       ---NOTE: This function shouldn't do any expensive actions as it is run on each
       ---render.
       ---
-      ---@type fun(bufnr: number): barbecue.Config.custom_section
+      ---@type fun(bufnr: number, winnr: number): barbecue.Config.custom_section
       lead_custom_section = function() return " " end,
     
       ---@alias barbecue.Config.custom_section
@@ -323,7 +323,7 @@ Click to see default config
       ---NOTE: This function shouldn't do any expensive actions as it is run on each
       ---render.
       ---
-      ---@type fun(bufnr: number): barbecue.Config.custom_section
+      ---@type fun(bufnr: number, winnr: number): barbecue.Config.custom_section
       custom_section = function() return " " end,
     
       ---@alias barbecue.Config.theme

--- a/lua/barbecue/config/template.lua
+++ b/lua/barbecue/config/template.lua
@@ -69,7 +69,7 @@ local M = {
   ---NOTE: This function shouldn't do any expensive actions as it is run on each
   ---render.
   ---
-  ---@type fun(bufnr: number): barbecue.Config.custom_section
+  ---@type fun(bufnr: number, winnr: number): barbecue.Config.custom_section
   lead_custom_section = function() return " " end,
 
   ---@alias barbecue.Config.custom_section
@@ -81,7 +81,7 @@ local M = {
   ---NOTE: This function shouldn't do any expensive actions as it is run on each
   ---render.
   ---
-  ---@type fun(bufnr: number): barbecue.Config.custom_section
+  ---@type fun(bufnr: number, winnr: number): barbecue.Config.custom_section
   custom_section = function() return " " end,
 
   ---@alias barbecue.Config.theme

--- a/lua/barbecue/ui.lua
+++ b/lua/barbecue/ui.lua
@@ -183,9 +183,9 @@ function M.update(winnr)
     end
 
     local lead_custom_section, lead_custom_section_length =
-      extract_custom_section(config.user.lead_custom_section(bufnr))
+      extract_custom_section(config.user.lead_custom_section(bufnr, winnr))
     local custom_section, custom_section_length =
-      extract_custom_section(config.user.custom_section(bufnr))
+      extract_custom_section(config.user.custom_section(bufnr, winnr))
     local entries = create_entries(
       winnr,
       bufnr,


### PR DESCRIPTION
## Changes

Passes window handles to custom section generators

## Rationale

The custom sections may depend on the parent window, considering they're unique
to each window. For example my own usecase involved getting the window number
from `vim.api.nvim_vim_get_number` which worked _fine_ once the winbars were updated
on switching windows but not on session restoration.
