### PR TITLE
feat: dir_display_limit

### DIFF
--- a/lua/barbecue/config/template.lua
+++ b/lua/barbecue/config/template.lua
@@ -41,6 +41,14 @@ local M = {
   ---@type boolean
   show_dirname = true,
 
+  ---Limits the number of directories to display.
+  ---Any number below 1 disables this feature.
+  ---
+  ---NOTE: Requires show_dirname to be enabled
+  ---
+  ---@type number
+  dir_display_limit = 0,
+
   ---Whether to display file name.
   ---
   ---@type boolean

--- a/lua/barbecue/ui/components.lua
+++ b/lua/barbecue/ui/components.lua
@@ -47,11 +47,16 @@ function M.dirname(bufnr)
   end
 
   local dirs = vim.split(dirname, PATH_SEPARATOR, { trimempty = true })
-  for _, dir in ipairs(dirs) do
+  local dir_display_limit = math.floor(config.user.dir_display_limit)
+  local dirs_start_index = (
+    dir_display_limit >= 1 and #dirs - dir_display_limit or 0
+  ) + 1
+
+  for i = math.max(dirs_start_index, 1), #dirs, 1 do
     table.insert(
       entries,
       Entry.new({
-        dir,
+        dirs[i],
         highlight = theme.highlights.dirname,
       })
     )


### PR DESCRIPTION
New feature to limit the number of directories to display.
Especially useful when working with something like Spring Boot, where just the directory name takes more than 50% of my screen real estate.