### PR TITLE
fix: skip basename entry if buffer is directory

### DIFF
--- a/lua/barbecue/ui/components.lua
+++ b/lua/barbecue/ui/components.lua
@@ -72,6 +72,8 @@ function M.basename(winnr, bufnr)
   local basename =
     vim.fn.fnamemodify(filename, config.user.modifiers.basename .. ":t")
 
+  if basename == "" then return nil end
+
   local icon
   if config.user.modified(bufnr) and config.user.show_modified then
     icon = {


### PR DESCRIPTION
If a buffer is a directory, `barbecue` should omit the basename (filename) entry, so the look will be cleaner.

I use `oil.nvim`, so without fix winbar is:

<img width="375" alt="image" src="https://github.com/utilyre/barbecue.nvim/assets/26388769/90bc190d-9591-4751-a7bd-fcae15ca6efb">

With fix entry with empty filename is removed:

<img width="362" alt="image" src="https://github.com/utilyre/barbecue.nvim/assets/26388769/30b13f63-0853-4183-a2f6-0fb27a8298af">
