### PR TITLE
fix: correct file icon for nested extensions

### DIFF
--- a/lua/barbecue/theme.lua
+++ b/lua/barbecue/theme.lua
@@ -154,7 +154,7 @@ function M.get_file_icon(filename, filetype)
   if not devicons_ok then return nil end
 
   local basename = vim.fn.fnamemodify(filename, ":t")
-  local extension = vim.fn.fnamemodify(filename, ":e")
+  local extension = string.match(basename, "%.(.*)")
 
   local icons = devicons.get_icons()
   local icon = icons[basename] or icons[extension]


### PR DESCRIPTION
The current method for getting the icon for a file doesn't account for nested file extensions

An example of this is `some-file.test.ts`. The current implementation will only load `ts` icons but will miss the icon for `test.ts`.

Before fix:

<img width="273" alt="default typescript icon not the flask icon" src="https://github.com/utilyre/barbecue.nvim/assets/23173408/bbdb511b-293d-4198-955b-27eb42a9a92d">

After fix:

<img width="273" alt="corrected flask icon for test file" src="https://github.com/utilyre/barbecue.nvim/assets/23173408/05f6c938-c237-4ef2-a811-d75aa9bf34e8">

The screenshots were testing [the default `nvim-web-devicons` set](https://github.com/nvim-tree/nvim-web-devicons/blob/14ac5887110b06b89a96881d534230dac3ed134d/lua/nvim-web-devicons/icons-default.lua#L1649) for `test.ts` vs `.ts`

We could make this more future-proof by recursively testing the nested extensions against the list of icons provided by `nvim-web-devicons`, but I couldn't think of a use case for this so opted out of supporting that just in case it was overkill