### PR TITLE
 Allow using a function to exclude filetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,11 @@ you've seen in the select menu of raw `:Barbecue`.
   ---@type string[]
   include_buftypes = { "" },
 
+  --- Function that returns whether to exclude the winbar for the given filetype or not.
+  ---
+  ---@type function
+  exclude_filetype_fn = function(filetype) return false end,
+
   ---Filetypes not to enable winbar in.
   ---
   ---@type string[]

--- a/lua/barbecue/config/template.lua
+++ b/lua/barbecue/config/template.lua
@@ -15,6 +15,11 @@ local M = {
   ---@type string[]
   include_buftypes = { "" },
 
+  --- Function that returns whether to exclude the winbar for the given filetype or not.
+  ---
+  ---@type function
+  exclude_filetype_fn = function(filetype) return false end,
+
   ---Filetypes not to enable winbar in.
   ---
   ---@type string[]

--- a/lua/barbecue/ui.lua
+++ b/lua/barbecue/ui.lua
@@ -178,6 +178,7 @@ function M.update(winnr)
   if
     not vim.tbl_contains(config.user.include_buftypes, vim.bo[bufnr].buftype)
     or vim.tbl_contains(config.user.exclude_filetypes, vim.bo[bufnr].filetype)
+    or config.user.exclude_filetype_fn(vim.bo[bufnr].filetype)
     or vim.api.nvim_win_get_config(winnr).relative ~= ""
     or (
       not config.user.show_dirname


### PR DESCRIPTION
I use this because it has allowed me to change my config from this:

```lua
      exclude_filetypes = {
        "netrw",
        "toggleterm",
        "NeogitCommitMessage",
        "NeogitCommitView",
        "NeogitDiffView",
        "NeogitHelpPopup",
        "NeogitLogPopup",
        -- ...bunch more Neogit buffers
      },
```

to this:

```lua
      exclude_filetype_fn = function(filetype)
        return string.find(filetype, "Neogit")
      end,
```