### PR TITLE
fix: use window cursor position before getting nvim-navic context

### DIFF
--- a/lua/barbecue/ui/components.lua
+++ b/lua/barbecue/ui/components.lua
@@ -181,6 +181,8 @@ function M.context(winnr, bufnr)
   if not config.user.show_navic then return {} end
   if not navic.is_available() then return {} end
 
+  local cursor_pos = vim.api.nvim_win_get_cursor(winnr)
+  require("nvim-navic.lib").update_context(bufnr, cursor_pos)
   local nestings = navic.get_data(bufnr)
   if nestings == nil then return {} end
 


### PR DESCRIPTION
I have `show_modified = true` in my config for barbecue, and as I was using it, I noticed that if I had a buffer open in two windows, if I modified the buffer in one of the windows, it wouldn't show as modified in the other window:

https://github.com/user-attachments/assets/5d727302-b7ab-4598-9905-24b73b699810

The reason for this is because even though I had an auto command to run `require("barbecue.ui").update()` when `BufModifiedSet` is triggered, by default the `update` function only operates on the current window. So to fix this issue, I tweaked my auto command to make sure it ran the `update` function on each window that has the buffer:

```lua
  vim.api.nvim_create_autocmd({
    "BufModifiedSet",
  }, {
    group = augroup,
    callback = function(args)
      local winnrs = vim.fn.win_findbuf(args.buf)
      for _, winnr in ipairs(winnrs) do
        require("barbecue.ui").update(winnr)
      end
    end,
  })
```

This worked to solve the issue of the mismatching modified signs:


https://github.com/user-attachments/assets/5225bdb2-e349-4cc1-aa93-436843574299

However, I then noticed the context from `nvim-navic` now was always the same on each window even though the cursor was at different places.

The reason for this is because when the `update` function is called, when it gets the context data from navic, navic returns the latest cached entry it has for the target buffer for the current window. In order to fix this problem, we need to make sure to update the navic data according to where the cursor is in the specific window we are getting the context for. This PR does this.

Now the modified symbol and context shows properly when I have the same buffer in two windows:

https://github.com/user-attachments/assets/8237aa8d-de10-4198-a57d-72c0989a5ad5

