### PR TITLE
feat: Add icon position config parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,12 +260,12 @@ you've seen in the select menu of raw `:Barbecue`.
   ---Buftypes to enable winbar in.
   ---
   ---@type string[]
-  include_buftypes = { "" },
+  include_buftypes = { "acwrite" },
 
   ---Filetypes not to enable winbar in.
   ---
   ---@type string[]
-  exclude_filetypes = { "netrw", "toggleterm" },
+  exclude_filetypes = { "", "netrw", "toggleterm" },
 
   modifiers = {
     ---Filename modifiers applied to dirname.

--- a/README.md
+++ b/README.md
@@ -293,6 +293,11 @@ you've seen in the select menu of raw `:Barbecue`.
   ---@type boolean
   show_basename = true,
 
+  ---Position of the icon relative to the filename. Can be "before" or "after".
+  ---
+  ---@type '"before"'|'"after"'
+  icon_position = "before",
+
   ---Whether to replace file icon with the modified symbol when buffer is
   ---modified.
   ---

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ you've seen in the select menu of raw `:Barbecue`.
   ---Filetypes not to enable winbar in.
   ---
   ---@type string[]
-  exclude_filetypes = { "", "netrw", "toggleterm" },
+  exclude_filetypes = { "netrw", "toggleterm" },
 
   modifiers = {
     ---Filename modifiers applied to dirname.

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ you've seen in the select menu of raw `:Barbecue`.
   ---Buftypes to enable winbar in.
   ---
   ---@type string[]
-  include_buftypes = { "acwrite" },
+  include_buftypes = { "", "acwrite" },
 
   ---Filetypes not to enable winbar in.
   ---

--- a/doc/barbecue.txt
+++ b/doc/barbecue.txt
@@ -253,7 +253,7 @@ Click to see default config
       ---Buftypes to enable winbar in.
       ---
       ---@type string[]
-      include_buftypes = { "acwrite" },
+      include_buftypes = { "", "acwrite" },
 
       ---Filetypes not to enable winbar in.
       ---

--- a/doc/barbecue.txt
+++ b/doc/barbecue.txt
@@ -253,12 +253,12 @@ Click to see default config
       ---Buftypes to enable winbar in.
       ---
       ---@type string[]
-      include_buftypes = { "" },
+      include_buftypes = { "acwrite" },
 
       ---Filetypes not to enable winbar in.
       ---
       ---@type string[]
-      exclude_filetypes = { "netrw", "toggleterm" },
+      exclude_filetypes = { "", "netrw", "toggleterm" },
 
       modifiers = {
         ---Filename modifiers applied to dirname.

--- a/doc/barbecue.txt
+++ b/doc/barbecue.txt
@@ -258,7 +258,7 @@ Click to see default config
       ---Filetypes not to enable winbar in.
       ---
       ---@type string[]
-      exclude_filetypes = { "", "netrw", "toggleterm" },
+      exclude_filetypes = { "netrw", "toggleterm" },
 
       modifiers = {
         ---Filename modifiers applied to dirname.

--- a/doc/barbecue.txt
+++ b/doc/barbecue.txt
@@ -100,10 +100,10 @@ API ~
     >
         -- hide barbecue globally
         require("barbecue.ui").toggle(false)
-        
+
         -- show barbecue globally
         require("barbecue.ui").toggle(true)
-        
+
         -- toggle barbecue globally
         require("barbecue.ui").toggle()
     <
@@ -112,7 +112,7 @@ API ~
     >
         -- update the current window's winbar
         require("barbecue.ui").update()
-        
+
         -- update the given window's winbar
         require("barbecue.ui").update(winnr)
     <
@@ -121,10 +121,10 @@ API ~
     >
         -- navigate to the second entry
         require("barbecue.ui").navigate(2)
-        
+
         -- navigate to the last entry
         require("barbecue.ui").navigate(-1)
-        
+
         -- just like before but on the given window
         require("barbecue.ui").navigate(index, winnr)
     <
@@ -137,17 +137,17 @@ RECIPES                                                     *barbecue-recipes*
     >
         -- triggers CursorHold event faster
         vim.opt.updatetime = 200
-        
+
         require("barbecue").setup({
           create_autocmd = false, -- prevent barbecue from updating itself automatically
         })
-        
+
         vim.api.nvim_create_autocmd({
           "WinScrolled", -- or WinResized on NVIM-v0.9 and higher
           "BufWinEnter",
           "CursorHold",
           "InsertLeave",
-        
+
           -- include this if you have set `show_modified` to `true`
           "BufModifiedSet",
         }, {
@@ -168,17 +168,17 @@ RECIPES                                                     *barbecue-recipes*
             -- you can take advantage of its `bg` and set a background throughout your winbar
             -- (e.g. basename will look like this: { fg = "#c0caf5", bold = true })
             normal = { fg = "#c0caf5" },
-        
+
             -- these highlights correspond to symbols table from config
             ellipsis = { fg = "#737aa2" },
             separator = { fg = "#737aa2" },
             modified = { fg = "#737aa2" },
-        
+
             -- these highlights represent the _text_ of three main parts of barbecue
             dirname = { fg = "#737aa2" },
             basename = { bold = true },
             context = {},
-        
+
             -- these highlights are used for context/navic icons
             context_file = { fg = "#ac8fe4" },
             context_module = { fg = "#ac8fe4" },
@@ -215,20 +215,20 @@ RECIPES                                                     *barbecue-recipes*
         require("barbecue").setup({
           attach_navic = false, -- prevent barbecue from automatically attaching nvim-navic
         })
-        
+
         require("lspconfig")[server].setup({
           -- ...
-        
+
           on_attach = function(client, bufnr)
             -- ...
-        
+
             if client.server_capabilities["documentSymbolProvider"] then
               require("nvim-navic").attach(client, bufnr)
             end
-        
+
             -- ...
           end,
-        
+
           -- ...
         })
     <
@@ -244,22 +244,22 @@ Click to see default config
       ---
       ---@type boolean
       attach_navic = true,
-    
+
       ---Whether to create winbar updater autocmd.
       ---
       ---@type boolean
       create_autocmd = true,
-    
+
       ---Buftypes to enable winbar in.
       ---
       ---@type string[]
       include_buftypes = { "" },
-    
+
       ---Filetypes not to enable winbar in.
       ---
       ---@type string[]
       exclude_filetypes = { "netrw", "toggleterm" },
-    
+
       modifiers = {
         ---Filename modifiers applied to dirname.
         ---
@@ -267,7 +267,7 @@ Click to see default config
         ---
         ---@type string
         dirname = ":~:.",
-    
+
         ---Filename modifiers applied to basename.
         ---
         ---See: `:help filename-modifiers`
@@ -275,35 +275,40 @@ Click to see default config
         ---@type string
         basename = "",
       },
-    
+
       ---Whether to display path to file.
       ---
       ---@type boolean
       show_dirname = true,
-    
+
       ---Whether to display file name.
       ---
       ---@type boolean
       show_basename = true,
-    
+
+      ---Position of the icon relative to the filename. Can be "before" or "after".
+      ---
+      ---@type '"before"'|'"after"'
+      icon_position = "before",
+
       ---Whether to replace file icon with the modified symbol when buffer is
       ---modified.
       ---
       ---@type boolean
       show_modified = false,
-    
+
       ---Get modified status of file.
       ---
       ---NOTE: This can be used to get file modified status from SCM (e.g. git)
       ---
       ---@type fun(bufnr: number): boolean
       modified = function(bufnr) return vim.bo[bufnr].modified end,
-    
+
       ---Whether to show/use navic in the winbar.
       ---
       ---@type boolean
       show_navic = true,
-    
+
       ---Get leading custom section contents.
       ---
       ---NOTE: This function shouldn't do any expensive actions as it is run on each
@@ -311,7 +316,7 @@ Click to see default config
       ---
       ---@type fun(bufnr: number, winnr: number): barbecue.Config.custom_section
       lead_custom_section = function() return " " end,
-    
+
       ---@alias barbecue.Config.custom_section
       ---|string # Literal string.
       ---|{ [1]: string, [2]: string? }[] # List-like table of `[text, highlight?]` tuples in which `highlight` is optional.
@@ -323,7 +328,7 @@ Click to see default config
       ---
       ---@type fun(bufnr: number, winnr: number): barbecue.Config.custom_section
       custom_section = function() return " " end,
-    
+
       ---@alias barbecue.Config.theme
       ---|'"auto"' # Use your current colorscheme's theme or generate a theme based on it.
       ---|string # Theme located under `barbecue.theme` module.
@@ -333,29 +338,29 @@ Click to see default config
       ---
       ---@type barbecue.Config.theme
       theme = "auto",
-    
+
       ---Whether context text should follow its icon's color.
       ---
       ---@type boolean
       context_follow_icon_color = false,
-    
+
       symbols = {
         ---Modification indicator.
         ---
         ---@type string
         modified = "●",
-    
+
         ---Truncation indicator.
         ---
         ---@type string
         ellipsis = "…",
-    
+
         ---Entry separator.
         ---
         ---@type string
         separator = "",
       },
-    
+
       ---@alias barbecue.Config.kinds
       ---|false # Disable kind icons.
       ---|table<string, string> # Type to icon mapping.

--- a/lua/barbecue/autocmd.lua
+++ b/lua/barbecue/autocmd.lua
@@ -1,4 +1,3 @@
-local navic = require("nvim-navic")
 local config = require("barbecue.config")
 local ui = require("barbecue.ui")
 local utils = require("barbecue.utils")
@@ -17,8 +16,9 @@ function M.create_navic_attacher()
     group = vim.api.nvim_create_augroup(GROUP_NAVIC_ATTACHER, {}),
     callback = function(a)
       local client = vim.lsp.get_client_by_id(a.data.client_id)
+      if not client then return end
       if client.server_capabilities["documentSymbolProvider"] then
-        navic.attach(client, a.buf)
+        require("nvim-navic").attach(client, a.buf)
       end
     end,
   })

--- a/lua/barbecue/config/template.lua
+++ b/lua/barbecue/config/template.lua
@@ -13,7 +13,7 @@ local M = {
   ---Buftypes to enable winbar in.
   ---
   ---@type string[]
-  include_buftypes = { "acwrite" },
+  include_buftypes = { "", "acwrite" },
 
   ---Filetypes not to enable winbar in.
   ---

--- a/lua/barbecue/config/template.lua
+++ b/lua/barbecue/config/template.lua
@@ -18,7 +18,7 @@ local M = {
   ---Filetypes not to enable winbar in.
   ---
   ---@type string[]
-  exclude_filetypes = { "", "netrw", "toggleterm" },
+  exclude_filetypes = { "netrw", "toggleterm" },
 
   modifiers = {
     ---Filename modifiers applied to dirname.

--- a/lua/barbecue/config/template.lua
+++ b/lua/barbecue/config/template.lua
@@ -13,12 +13,12 @@ local M = {
   ---Buftypes to enable winbar in.
   ---
   ---@type string[]
-  include_buftypes = { "" },
+  include_buftypes = { "acwrite" },
 
   ---Filetypes not to enable winbar in.
   ---
   ---@type string[]
-  exclude_filetypes = { "netrw", "toggleterm" },
+  exclude_filetypes = { "", "netrw", "toggleterm" },
 
   modifiers = {
     ---Filename modifiers applied to dirname.

--- a/lua/barbecue/config/template.lua
+++ b/lua/barbecue/config/template.lua
@@ -46,6 +46,11 @@ local M = {
   ---@type boolean
   show_basename = true,
 
+  ---Position of the icon relative to the filename. Can be "before" or "after".
+  ---
+  ---@type '"before"'|'"after"'
+  icon_position = "before",
+
   ---Whether to replace file icon with the modified symbol when buffer is
   ---modified.
   ---

--- a/lua/barbecue/theme.lua
+++ b/lua/barbecue/theme.lua
@@ -154,7 +154,7 @@ function M.get_file_icon(filename, filetype)
   if not devicons_ok then return nil end
 
   local basename = vim.fn.fnamemodify(filename, ":t")
-  local extension = vim.fn.fnamemodify(filename, ":e")
+  local extension = string.match(basename, "%.(.*)")
 
   local icons = devicons.get_icons()
   local icon = icons[basename] or icons[extension]

--- a/lua/barbecue/ui.lua
+++ b/lua/barbecue/ui.lua
@@ -105,7 +105,7 @@ local function create_entries(winnr, bufnr, extra_length)
   local dirname = components.dirname(bufnr)
 
   -- Don't apply in toggleterm
-  local type = dirname[1].text[1]
+  local type = dirname[1] and dirname[1].text and dirname[1].text[1]
   if type == "term://" then
       return nil
   end

--- a/lua/barbecue/ui.lua
+++ b/lua/barbecue/ui.lua
@@ -103,6 +103,13 @@ local function create_entries(winnr, bufnr, extra_length)
   if vim.api.nvim_buf_get_name(bufnr) == "" then return nil end
 
   local dirname = components.dirname(bufnr)
+
+  -- Don't apply in toggleterm
+  local type = dirname[1].text[1]
+  if type == "term://" then
+      return nil
+  end
+
   local basename = components.basename(winnr, bufnr)
   local context = components.context(winnr, bufnr)
 

--- a/lua/barbecue/ui.lua
+++ b/lua/barbecue/ui.lua
@@ -106,9 +106,7 @@ local function create_entries(winnr, bufnr, extra_length)
 
   -- Don't apply in toggleterm
   local type = dirname[1] and dirname[1].text and dirname[1].text[1]
-  if type == "term://" then
-      return nil
-  end
+  if type == "term://" then return nil end
 
   local basename = components.basename(winnr, bufnr)
   local context = components.context(winnr, bufnr)

--- a/lua/barbecue/ui/components.lua
+++ b/lua/barbecue/ui/components.lua
@@ -22,6 +22,10 @@ function M.dirname(bufnr)
   local entries = {}
 
   if dirname == "." then return {} end
+
+  -- Sanitize oil paths
+  dirname = dirname:gsub("^oil:?/?", "/")
+
   if dirname:sub(1, 1) == "/" then
     table.insert(
       entries,

--- a/lua/barbecue/ui/components.lua
+++ b/lua/barbecue/ui/components.lua
@@ -1,4 +1,3 @@
-local navic = require("nvim-navic")
 local config = require("barbecue.config")
 local theme = require("barbecue.theme")
 local Entry = require("barbecue.ui.entry")
@@ -183,6 +182,8 @@ end
 ---@return barbecue.Entry[]
 function M.context(winnr, bufnr)
   if not config.user.show_navic then return {} end
+
+  local navic = require("nvim-navic")
   if not navic.is_available() then return {} end
 
   local nestings = navic.get_data(bufnr)

--- a/lua/barbecue/ui/entry.lua
+++ b/lua/barbecue/ui/entry.lua
@@ -1,3 +1,4 @@
+local config = require("barbecue.config")
 local utils = require("barbecue.utils")
 local theme = require("barbecue.theme")
 
@@ -62,29 +63,46 @@ end
 ---
 ---@return string
 function Entry:to_string()
-  return (
-    (
-      self.to == nil and ""
-      or string.format(
-        "%%@v:lua.require'barbecue.ui.mouse'.navigate_%d_%d_%d@",
-        self.to.win,
-        self.to.pos[1],
-        self.to.pos[2]
-      )
+  local mouse = (
+    self.to == nil and ""
+    or string.format(
+      "%%@v:lua.require'barbecue.ui.mouse'.navigate_%d_%d_%d@",
+      self.to.win,
+      self.to.pos[1],
+      self.to.pos[2]
     )
-    .. (self.icon == nil and "" or string.format(
-      "%%#%s#%s%%#%s# ",
+  )
+
+  local icon_fmt = "%%#%s#%s%%#%s#"
+  if config.user.icon_position == "after" then
+    icon_fmt = " " .. icon_fmt
+  else
+    icon_fmt = icon_fmt .. " "
+  end
+
+  local icon = (
+    self.icon == nil and ""
+    or string.format(
+      icon_fmt,
       self.icon.highlight,
       utils.str_escape(self.icon[1]),
       theme.highlights.normal
-    ))
-    .. string.format(
-      "%%#%s#%s",
-      self.text.highlight,
-      utils.str_escape(self.text[1])
     )
-    .. (self.to == nil and "" or "%X")
   )
+
+  local text = string.format(
+    "%%#%s#%s",
+    self.text.highlight,
+    utils.str_escape(self.text[1])
+  )
+
+  local to = (self.to == nil and "" or "%X")
+
+  if config.user.icon_position == "after" then
+    return (mouse .. text .. icon .. to)
+  else
+    return (mouse .. icon .. text .. to)
+  end
 end
 
 ---Move cursor to where the Entry points to.


### PR DESCRIPTION
This PR adds a configuration option for the icon position.

It allows setting the icon to before or after the filename text.

![image](https://github.com/user-attachments/assets/d2431354-4653-4fb5-982f-90eaebdbfc8d)